### PR TITLE
feat: build postgres images from scratch

### DIFF
--- a/.github/workflows/build-and-push-exporter.yml
+++ b/.github/workflows/build-and-push-exporter.yml
@@ -1,0 +1,59 @@
+name: Build and Push PG Exporter
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - metrics/**
+      - .github/workflows/build-and-push-exporter.yml
+
+env:
+  REGISTRY: ghcr.io
+  EXPORTER_IMAGE_NAME: ${{ github.repository }}/pg-exporter
+
+jobs:
+  build-exporter:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata - PG Exporter
+        id: meta-exporter
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.EXPORTER_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      - name: Build and push - PG Exporter
+        uses: docker/build-push-action@v5
+        with:
+          context: ./metrics
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-exporter.outputs.tags }}
+          labels: ${{ steps.meta-exporter.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-push-fly.yml
+++ b/.github/workflows/build-and-push-fly.yml
@@ -1,0 +1,171 @@
+name: Build and Push Fly Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile.base
+      - Dockerfile.postgis
+      - scripts/**
+      - postgres-oom-adjuster.sh
+      - .github/workflows/build-and-push-fly.yml
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/mpg-operator-postgres
+
+jobs:
+
+  # ── Scratch-built base images ─────────────────────────────────────────────────
+  # Full from-scratch builds using Percona + EPEL repos on UBI9 minimal.
+  build-base:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata - fly-pg16
+        id: meta-fly-pg16
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=fly-pg16
+            type=sha,format=short,suffix=-fly-pg16
+            type=raw,value={{date 'YYYYMMDD'}},suffix=-fly-pg16
+
+      - name: Extract metadata - fly-pg17
+        id: meta-fly-pg17
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=fly-pg17
+            type=sha,format=short,suffix=-fly-pg17
+            type=raw,value={{date 'YYYYMMDD'}},suffix=-fly-pg17
+
+      - name: Build and push - fly-pg16
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.base
+          build-args: |
+            PG_MAJOR=16
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-fly-pg16.outputs.tags }}
+          labels: ${{ steps.meta-fly-pg16.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push - fly-pg17
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.base
+          build-args: |
+            PG_MAJOR=17
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-fly-pg17.outputs.tags }}
+          labels: ${{ steps.meta-fly-pg17.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Scratch-built PostGIS images ──────────────────────────────────────────────
+  # Layered on top of fly-pg16/fly-pg17 with PostGIS from PGDG.
+  build-postgis:
+    needs: build-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata - fly-pg16-postgis
+        id: meta-fly-pg16-postgis
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=fly-pg16-postgis
+            type=sha,format=short,suffix=-fly-pg16-postgis
+            type=raw,value={{date 'YYYYMMDD'}},suffix=-fly-pg16-postgis
+
+      - name: Extract metadata - fly-pg17-postgis
+        id: meta-fly-pg17-postgis
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=fly-pg17-postgis
+            type=sha,format=short,suffix=-fly-pg17-postgis
+            type=raw,value={{date 'YYYYMMDD'}},suffix=-fly-pg17-postgis
+
+      - name: Build and push - fly-pg16-postgis
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.postgis
+          build-args: |
+            PG_MAJOR=16
+            REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            BASE_TAG=fly-pg16
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-fly-pg16-postgis.outputs.tags }}
+          labels: ${{ steps.meta-fly-pg16-postgis.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push - fly-pg17-postgis
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.postgis
+          build-args: |
+            PG_MAJOR=17
+            REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            BASE_TAG=fly-pg17
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-fly-pg17-postgis.outputs.tags }}
+          labels: ${{ steps.meta-fly-pg17-postgis.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-push-fly.yml
+++ b/.github/workflows/build-and-push-fly.yml
@@ -14,6 +14,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/mpg-operator-postgres
+  PG16_VERSION: "16.14"
+  PG17_VERSION: "17.10"
+  PATRONI_VERSION: "4.1.3"
 
 jobs:
 
@@ -28,13 +31,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -70,7 +70,9 @@ jobs:
           file: Dockerfile.base
           build-args: |
             PG_MAJOR=16
-          platforms: linux/amd64,linux/arm64
+            PG_FULL_VERSION=${{ env.PG16_VERSION }}
+            PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta-fly-pg16.outputs.tags }}
           labels: ${{ steps.meta-fly-pg16.outputs.labels }}
@@ -84,7 +86,9 @@ jobs:
           file: Dockerfile.base
           build-args: |
             PG_MAJOR=17
-          platforms: linux/amd64,linux/arm64
+            PG_FULL_VERSION=${{ env.PG17_VERSION }}
+            PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta-fly-pg17.outputs.tags }}
           labels: ${{ steps.meta-fly-pg17.outputs.labels }}
@@ -103,13 +107,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -147,7 +148,7 @@ jobs:
             PG_MAJOR=16
             REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             BASE_TAG=fly-pg16
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta-fly-pg16-postgis.outputs.tags }}
           labels: ${{ steps.meta-fly-pg16-postgis.outputs.labels }}
@@ -163,7 +164,7 @@ jobs:
             PG_MAJOR=17
             REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             BASE_TAG=fly-pg17
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta-fly-pg17-postgis.outputs.tags }}
           labels: ${{ steps.meta-fly-pg17-postgis.outputs.labels }}

--- a/.github/workflows/build-and-push-fly.yml
+++ b/.github/workflows/build-and-push-fly.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - Dockerfile.base
       - Dockerfile.postgis
+      - Dockerfile.pgbackrest
       - scripts/**
       - postgres-oom-adjuster.sh
       - .github/workflows/build-and-push-fly.yml
@@ -17,6 +18,7 @@ env:
   PG16_VERSION: "16.14"
   PG17_VERSION: "17.10"
   PATRONI_VERSION: "4.1.3"
+  PGBACKREST_VERSION: "2.54.2"
 
 jobs:
 
@@ -72,6 +74,7 @@ jobs:
             PG_MAJOR=16
             PG_FULL_VERSION=${{ env.PG16_VERSION }}
             PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+            PGBACKREST_VERSION=${{ env.PGBACKREST_VERSION }}
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta-fly-pg16.outputs.tags }}
@@ -88,6 +91,7 @@ jobs:
             PG_MAJOR=17
             PG_FULL_VERSION=${{ env.PG17_VERSION }}
             PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+            PGBACKREST_VERSION=${{ env.PGBACKREST_VERSION }}
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta-fly-pg17.outputs.tags }}
@@ -168,5 +172,54 @@ jobs:
           push: true
           tags: ${{ steps.meta-fly-pg17-postgis.outputs.tags }}
           labels: ${{ steps.meta-fly-pg17-postgis.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── pgBackRest repo-host image ────────────────────────────────────────────────
+  # Slim dedicated image — no PostgreSQL or Patroni. The operator's repo-host pod
+  # only needs the pgbackrest binary, bash (config reloader + nss-wrapper-init),
+  # and nss_wrapper. Independent of postgres major version.
+  build-pgbackrest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata - fly-pgbackrest
+        id: meta-fly-pgbackrest
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=fly-pgbackrest
+            type=sha,format=short,suffix=-fly-pgbackrest
+            type=raw,value={{date 'YYYYMMDD'}},suffix=-fly-pgbackrest
+
+      - name: Build and push - fly-pgbackrest
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.pgbackrest
+          build-args: |
+            PGBACKREST_VERSION=${{ env.PGBACKREST_VERSION }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-fly-pgbackrest.outputs.tags }}
+          labels: ${{ steps.meta-fly-pgbackrest.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - Dockerfile
+      - entrypoint-wrapper.sh
+      - postgres-oom-adjuster.sh
+      - .github/workflows/build-and-push.yml
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/mpg-operator-postgres
-  EXPORTER_IMAGE_NAME: ${{ github.repository }}/pg-exporter
 
 jobs:
   build-and-push:
@@ -129,23 +133,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Extract metadata for Docker - PG Exporter
-        id: meta-exporter
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.EXPORTER_IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha,format=short
-            type=raw,value={{date 'YYYYMMDD'}}
-
-      - name: Build and push Docker image - PG Exporter
-        uses: docker/build-push-action@v5
-        with:
-          context: ./metrics
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta-exporter.outputs.tags }}
-          labels: ${{ steps.meta-exporter.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/build-pr-exporter.yml
+++ b/.github/workflows/build-pr-exporter.yml
@@ -1,0 +1,48 @@
+name: Build PR PG Exporter
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - metrics/**
+      - .github/workflows/build-pr-exporter.yml
+
+env:
+  REGISTRY: ghcr.io
+  EXPORTER_IMAGE_NAME: ${{ github.repository }}/pg-exporter
+
+jobs:
+  build-exporter-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push - pr-${{ github.event.pull_request.number }}-pg-exporter
+        uses: docker/build-push-action@v5
+        with:
+          context: ./metrics
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.EXPORTER_IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-pr-fly.yml
+++ b/.github/workflows/build-pr-fly.yml
@@ -1,0 +1,123 @@
+name: Build PR Fly Images
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile.base
+      - Dockerfile.postgis
+      - scripts/**
+      - postgres-oom-adjuster.sh
+      - .github/workflows/build-pr-fly.yml
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/mpg-operator-postgres
+
+jobs:
+
+  build-base-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push - pr-${{ github.event.pull_request.number }}-fly-pg16
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.base
+          build-args: |
+            PG_MAJOR=16
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg16
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push - pr-${{ github.event.pull_request.number }}-fly-pg17
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.base
+          build-args: |
+            PG_MAJOR=17
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg17
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-postgis-pr:
+    needs: build-base-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push - pr-${{ github.event.pull_request.number }}-fly-pg16-postgis
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.postgis
+          build-args: |
+            PG_MAJOR=16
+            REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            BASE_TAG=pr-${{ github.event.pull_request.number }}-fly-pg16
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg16-postgis
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push - pr-${{ github.event.pull_request.number }}-fly-pg17-postgis
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.postgis
+          build-args: |
+            PG_MAJOR=17
+            REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            BASE_TAG=pr-${{ github.event.pull_request.number }}-fly-pg17
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg17-postgis
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-pr-fly.yml
+++ b/.github/workflows/build-pr-fly.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - Dockerfile.base
       - Dockerfile.postgis
+      - Dockerfile.pgbackrest
       - scripts/**
       - postgres-oom-adjuster.sh
       - .github/workflows/build-pr-fly.yml
@@ -17,6 +18,7 @@ env:
   PG16_VERSION: "16.14"
   PG17_VERSION: "17.10"
   PATRONI_VERSION: "4.1.3"
+  PGBACKREST_VERSION: "2.54.2"
 
 jobs:
 
@@ -50,6 +52,7 @@ jobs:
             PG_MAJOR=16
             PG_FULL_VERSION=${{ env.PG16_VERSION }}
             PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+            PGBACKREST_VERSION=${{ env.PGBACKREST_VERSION }}
           platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg16
@@ -65,6 +68,7 @@ jobs:
             PG_MAJOR=17
             PG_FULL_VERSION=${{ env.PG17_VERSION }}
             PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+            PGBACKREST_VERSION=${{ env.PGBACKREST_VERSION }}
           platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg17
@@ -120,5 +124,39 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg17-postgis
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-pgbackrest-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push - pr-${{ github.event.pull_request.number }}-fly-pgbackrest
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.pgbackrest
+          build-args: |
+            PGBACKREST_VERSION=${{ env.PGBACKREST_VERSION }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pgbackrest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-pr-fly.yml
+++ b/.github/workflows/build-pr-fly.yml
@@ -14,6 +14,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/mpg-operator-postgres
+  PG16_VERSION: "16.14"
+  PG17_VERSION: "17.10"
+  PATRONI_VERSION: "4.1.3"
 
 jobs:
 
@@ -26,13 +29,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -48,7 +48,9 @@ jobs:
           file: Dockerfile.base
           build-args: |
             PG_MAJOR=16
-          platforms: linux/amd64,linux/arm64
+            PG_FULL_VERSION=${{ env.PG16_VERSION }}
+            PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg16
           cache-from: type=gha
@@ -61,7 +63,9 @@ jobs:
           file: Dockerfile.base
           build-args: |
             PG_MAJOR=17
-          platforms: linux/amd64,linux/arm64
+            PG_FULL_VERSION=${{ env.PG17_VERSION }}
+            PATRONI_VERSION=${{ env.PATRONI_VERSION }}
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg17
           cache-from: type=gha
@@ -77,13 +81,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -101,7 +102,7 @@ jobs:
             PG_MAJOR=16
             REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             BASE_TAG=pr-${{ github.event.pull_request.number }}-fly-pg16
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg16-postgis
           cache-from: type=gha
@@ -116,7 +117,7 @@ jobs:
             PG_MAJOR=17
             REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             BASE_TAG=pr-${{ github.event.pull_request.number }}-fly-pg17
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-fly-pg17-postgis
           cache-from: type=gha

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,6 +3,8 @@ ARG PG_MAJOR=17
 FROM oraclelinux:9-slim
 
 ARG PG_MAJOR
+ARG PG_FULL_VERSION=17.10
+ARG PATRONI_VERSION=4.1.3
 
 LABEL maintainer="Fly.io" \
       description="PostgreSQL with Patroni for the Percona Operator 2.6, built from scratch"
@@ -39,7 +41,7 @@ RUN set -ex; \
       bind-utils gettext hostname python3-pyparsing perl libedit \
       openssh openssh-server openssh-clients procps-ng \
       libpq glibc-all-langpacks \
-      percona-postgresql${PG_MAJOR}; \
+      percona-postgresql${PG_MAJOR}-${PG_FULL_VERSION}; \
     microdnf -y reinstall tzdata; \
     microdnf clean all
 
@@ -49,15 +51,15 @@ RUN set -ex; \
       percona-pgaudit${PG_MAJOR} \
       percona-pgaudit${PG_MAJOR}_set_user \
       percona-pgbackrest \
-      percona-postgresql${PG_MAJOR}-contrib \
-      percona-postgresql${PG_MAJOR}-server \
-      percona-postgresql${PG_MAJOR}-libs \
+      percona-postgresql${PG_MAJOR}-contrib-${PG_FULL_VERSION} \
+      percona-postgresql${PG_MAJOR}-server-${PG_FULL_VERSION} \
+      percona-postgresql${PG_MAJOR}-libs-${PG_FULL_VERSION} \
       percona-pg_stat_monitor${PG_MAJOR} \
       percona-wal2json${PG_MAJOR} \
       percona-pg_repack${PG_MAJOR} \
       psmisc rsync perl nss_wrapper tar bzip2 lz4 file tzdata unzip \
       python3-psycopg2 python3-ydiff python3-dateutil python3-urllib3 \
-      python3-pyyaml python3-click ydiff percona-patroni; \
+      python3-pyyaml python3-click ydiff percona-patroni-${PATRONI_VERSION}; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,126 @@
+ARG PG_MAJOR=17
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG PG_MAJOR
+
+LABEL maintainer="Fly.io" \
+      description="PostgreSQL with Patroni for the Percona Operator 2.6, built from scratch"
+
+ENV LC_ALL=en_US.utf-8 \
+    LANG=en_US.utf-8 \
+    container=oci
+
+# ── Base OS ──────────────────────────────────────────────────────────────────
+RUN microdnf -y update && \
+    microdnf -y install glibc-langpack-en platform-python && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+# ── Repo setup: Percona + Fedora EPEL ────────────────────────────────────────
+# Both are noarch packages — no arch-specific URLs needed.
+RUN set -ex; \
+    microdnf -y install findutils; \
+    curl -Lfs -o /tmp/percona-release.rpm \
+      "https://repo.percona.com/yum/percona-release-latest.noarch.rpm"; \
+    curl -Lfs -o /tmp/epel-release.rpm \
+      "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"; \
+    rpm -i /tmp/percona-release.rpm /tmp/epel-release.rpm; \
+    percona-release enable ppg-${PG_MAJOR} release; \
+    rm -f /tmp/*.rpm; \
+    microdnf clean all
+
+ENV PGROOT=/usr/pgsql-${PG_MAJOR} \
+    PGVERSION=${PG_MAJOR}
+
+# ── PostgreSQL base package + system tools ───────────────────────────────────
+# llvmjit intentionally excluded: JIT is off by default in PG16+ and LLVM
+# adds complexity and image size with no operational benefit here.
+RUN set -ex; \
+    microdnf -y install \
+      bind-utils gettext hostname python3-pyparsing perl libedit \
+      openssh openssh-server openssh-clients procps-ng \
+      libpq glibc-all-langpacks \
+      percona-postgresql${PG_MAJOR}; \
+    microdnf -y reinstall tzdata; \
+    microdnf clean all
+
+# ── Extensions + Patroni (all RPM — no pip) ──────────────────────────────────
+RUN set -ex; \
+    microdnf -y install \
+      percona-pgaudit${PG_MAJOR} \
+      percona-pgaudit${PG_MAJOR}_set_user \
+      percona-pgbackrest \
+      percona-postgresql${PG_MAJOR}-contrib \
+      percona-postgresql${PG_MAJOR}-server \
+      percona-postgresql${PG_MAJOR}-libs \
+      percona-pg_stat_monitor${PG_MAJOR} \
+      percona-wal2json${PG_MAJOR} \
+      percona-pg_repack${PG_MAJOR} \
+      psmisc rsync perl nss_wrapper tar bzip2 lz4 file tzdata unzip \
+      python3-psycopg2 python3-ydiff python3-dateutil python3-urllib3 \
+      python3-pyyaml python3-click ydiff percona-patroni; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+# ── pgvector ─────────────────────────────────────────────────────────────────
+RUN set -ex; \
+    microdnf -y install percona-pgvector_${PG_MAJOR}; \
+    rpm -e percona-telemetry-agent --nodeps 2>/dev/null || true; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+ENV PATH=/usr/pgsql-${PG_MAJOR}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    NSS_WRAPPER_SUBDIR=postgres
+
+# ── Directory structure ───────────────────────────────────────────────────────
+RUN set -ex; \
+    mkdir -p \
+      /opt/crunchy/bin/postgres \
+      /opt/crunchy/conf \
+      /pgdata /pgwal /pgconf /backrestrepo /tablespaces /.ssh; \
+    chown -R postgres:postgres \
+      /opt/crunchy /var/lib/pgsql \
+      /pgdata /pgwal /pgconf /backrestrepo /tablespaces \
+      /usr/pgsql-${PG_MAJOR}; \
+    chmod -R g=u \
+      /opt/crunchy /var/lib/pgsql \
+      /pgdata /pgwal /pgconf /backrestrepo /tablespaces; \
+    chown 26:0 /.ssh; \
+    chmod g+rwx /.ssh; \
+    rm -f /run/nologin
+
+# ── Operator-required scripts ─────────────────────────────────────────────────
+# /usr/local/bin/relocate-extensions.sh  — called by extension-relocator init container
+# /opt/crunchy/bin/postgres/pgbackrest_info.sh — called by pgMonitor collector
+COPY scripts/relocate-extensions.sh /usr/local/bin/relocate-extensions.sh
+COPY scripts/crunchy/bin/postgres/pgbackrest_info.sh /opt/crunchy/bin/postgres/pgbackrest_info.sh
+RUN chmod +x \
+      /usr/local/bin/relocate-extensions.sh \
+      /opt/crunchy/bin/postgres/pgbackrest_info.sh
+
+# ── OOM protection ────────────────────────────────────────────────────────────
+# The operator sets command=["patroni", "/etc/patroni"] on the pod spec, bypassing
+# Docker ENTRYPOINT. We intercept by placing our wrapper at /usr/bin/patroni and
+# renaming the real binary to /usr/bin/patroni-real.
+# NOTE: oom_score_adj writes require CAP_SYS_RESOURCE. The wrapper fails silently
+# without it — no crash, just no OOM adjustment.
+COPY scripts/patroni-wrapper.sh /usr/local/bin/patroni-wrapper.sh
+COPY postgres-oom-adjuster.sh /usr/local/bin/postgres-oom-adjuster.sh
+RUN set -ex; \
+    mv /usr/bin/patroni /usr/bin/patroni-real; \
+    ln -sf /usr/local/bin/patroni-wrapper.sh /usr/bin/patroni; \
+    chmod +x \
+      /usr/local/bin/patroni-wrapper.sh \
+      /usr/local/bin/postgres-oom-adjuster.sh
+
+# ── PG tuning ─────────────────────────────────────────────────────────────────
+RUN echo "huge_pages = off" >> /usr/pgsql-${PG_MAJOR}/share/postgresql.conf.sample
+
+# ── Cleanup ───────────────────────────────────────────────────────────────────
+RUN rm -rf /var/spool/pgbackrest
+
+EXPOSE 5432
+VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/backrestrepo"]
+USER 26
+CMD ["/usr/bin/patroni"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -119,7 +119,11 @@ RUN set -ex; \
 RUN echo "huge_pages = off" >> /usr/pgsql-${PG_MAJOR}/share/postgresql.conf.sample
 
 # ── Cleanup ───────────────────────────────────────────────────────────────────
-RUN rm -rf /var/spool/pgbackrest
+# Remove RPM-installed default pgbackrest.conf (/etc/pgbackrest.conf ships with
+# repo-path=/var/lib/pgbackrest — the old 1.x alias for repo1-path). pgbackrest
+# 2.36+ treats both names in the same section as a duplicate error. The operator
+# manages all pgbackrest config exclusively via ConfigMaps in /etc/pgbackrest/conf.d/.
+RUN rm -f /etc/pgbackrest.conf && rm -rf /var/spool/pgbackrest
 
 EXPOSE 5432
 VOLUME ["/sshd", "/pgconf", "/pgdata", "/pgwal", "/backrestrepo"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,6 +5,7 @@ FROM oraclelinux:9-slim
 ARG PG_MAJOR
 ARG PG_FULL_VERSION=17.10
 ARG PATRONI_VERSION=4.1.3
+ARG PGBACKREST_VERSION=2.54.2
 
 LABEL maintainer="Fly.io" \
       description="PostgreSQL with Patroni for the Percona Operator 2.6, built from scratch"
@@ -50,7 +51,7 @@ RUN set -ex; \
     microdnf -y install \
       percona-pgaudit${PG_MAJOR} \
       percona-pgaudit${PG_MAJOR}_set_user \
-      percona-pgbackrest \
+      percona-pgbackrest-${PGBACKREST_VERSION} \
       percona-postgresql${PG_MAJOR}-contrib-${PG_FULL_VERSION} \
       percona-postgresql${PG_MAJOR}-server-${PG_FULL_VERSION} \
       percona-postgresql${PG_MAJOR}-libs-${PG_FULL_VERSION} \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,6 @@
 ARG PG_MAJOR=17
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM oraclelinux:9-slim
 
 ARG PG_MAJOR
 
@@ -17,15 +17,13 @@ RUN microdnf -y update && \
     microdnf clean all && \
     rm -rf /var/cache/dnf /var/cache/yum
 
-# ── Repo setup: Percona + Fedora EPEL ────────────────────────────────────────
-# Both are noarch packages — no arch-specific URLs needed.
+# ── Repo setup: Percona + Oracle EPEL ───────────────────────────────────────
+# oracle-epel-release-el9 is in Oracle Linux repos — no external download needed.
 RUN set -ex; \
-    microdnf -y install findutils; \
+    microdnf -y install findutils oracle-epel-release-el9; \
     curl -Lfs -o /tmp/percona-release.rpm \
       "https://repo.percona.com/yum/percona-release-latest.noarch.rpm"; \
-    curl -Lfs -o /tmp/epel-release.rpm \
-      "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"; \
-    rpm -i /tmp/percona-release.rpm /tmp/epel-release.rpm; \
+    rpm -i /tmp/percona-release.rpm; \
     percona-release enable ppg-${PG_MAJOR} release; \
     rm -f /tmp/*.rpm; \
     microdnf clean all

--- a/Dockerfile.pgbackrest
+++ b/Dockerfile.pgbackrest
@@ -39,7 +39,8 @@ RUN set -ex; \
       bash \
       tar \
       openssh-clients \
-      gettext; \
+      gettext \
+      procps-ng; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 

--- a/Dockerfile.pgbackrest
+++ b/Dockerfile.pgbackrest
@@ -45,6 +45,12 @@ RUN set -ex; \
 
 ENV NSS_WRAPPER_SUBDIR=postgres
 
+# ── Remove RPM default config ─────────────────────────────────────────────────
+# percona-pgbackrest ships /etc/pgbackrest.conf with repo-path (1.x alias).
+# pgbackrest 2.36+ errors when both repo-path and repo1-path appear in [global].
+# All config comes from operator ConfigMaps mounted at /etc/pgbackrest/conf.d/.
+RUN rm -f /etc/pgbackrest.conf
+
 # ── Directory structure ───────────────────────────────────────────────────────
 RUN set -ex; \
     mkdir -p \

--- a/Dockerfile.pgbackrest
+++ b/Dockerfile.pgbackrest
@@ -1,0 +1,64 @@
+ARG PGBACKREST_VERSION=2.54.2
+
+FROM oraclelinux:9-slim
+
+ARG PGBACKREST_VERSION
+
+LABEL maintainer="Fly.io" \
+      description="pgBackRest repo-host for the Percona Operator 2.6"
+
+ENV LC_ALL=en_US.utf-8 \
+    LANG=en_US.utf-8 \
+    container=oci
+
+# ── Base OS ──────────────────────────────────────────────────────────────────
+RUN microdnf -y update && \
+    microdnf -y install glibc-langpack-en && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+# ── Repo setup: Percona + Oracle EPEL ───────────────────────────────────────
+RUN set -ex; \
+    microdnf -y install findutils oracle-epel-release-el9; \
+    curl -Lfs -o /tmp/percona-release.rpm \
+      "https://repo.percona.com/yum/percona-release-latest.noarch.rpm"; \
+    rpm -i /tmp/percona-release.rpm; \
+    percona-release enable ppg-16 release; \
+    rm -f /tmp/*.rpm; \
+    microdnf clean all
+
+# ── pgBackRest + runtime deps ─────────────────────────────────────────────────
+# bash: required by the operator's config-reloader and nss-wrapper-init containers
+# nss_wrapper: operator injects LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+# openssh-clients: needed for SFTP repo type
+# Compression libs (lz4, bzip2, zstd) pulled in as RPM deps of percona-pgbackrest
+RUN set -ex; \
+    microdnf -y install \
+      percona-pgbackrest-${PGBACKREST_VERSION} \
+      nss_wrapper \
+      bash \
+      tar \
+      openssh-clients \
+      gettext; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+ENV NSS_WRAPPER_SUBDIR=postgres
+
+# ── Directory structure ───────────────────────────────────────────────────────
+RUN set -ex; \
+    mkdir -p \
+      /etc/pgbackrest/conf.d \
+      /var/log/pgbackrest \
+      /backrestrepo; \
+    chown -R 26:0 \
+      /etc/pgbackrest \
+      /var/log/pgbackrest \
+      /backrestrepo; \
+    chmod -R g=u \
+      /etc/pgbackrest \
+      /var/log/pgbackrest \
+      /backrestrepo
+
+USER 26
+CMD ["pgbackrest", "server"]

--- a/Dockerfile.postgis
+++ b/Dockerfile.postgis
@@ -1,0 +1,35 @@
+ARG REGISTRY=ghcr.io/superfly/mpg-postgres-image/mpg-operator-postgres
+ARG BASE_TAG
+ARG PG_MAJOR=16
+
+FROM ${REGISTRY}:${BASE_TAG}
+
+ARG PG_MAJOR
+ARG TARGETARCH
+
+LABEL maintainer="Fly.io" \
+      description="PostgreSQL with PostGIS and Patroni for the Percona Operator 2.6"
+
+USER 0
+
+# ── PostGIS via PGDG ──────────────────────────────────────────────────────────
+# Percona's repos don't include PostGIS; PGDG is the canonical source.
+# PGDG postgres packages (postgresql${PG_MAJOR}-*) have different names than
+# Percona's (percona-postgresql${PG_MAJOR}-*), so there are no conflicts.
+RUN set -ex; \
+    case "${TARGETARCH}" in \
+      amd64) PGDG_ARCH="x86_64" ;; \
+      arm64) PGDG_ARCH="aarch64" ;; \
+      *)     PGDG_ARCH=$(uname -m) ;; \
+    esac; \
+    curl -Lfs -o /tmp/pgdg-release.rpm \
+        "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-${PGDG_ARCH}/pgdg-redhat-repo-latest.noarch.rpm"; \
+    rpm -i /tmp/pgdg-release.rpm; \
+    rm -f /tmp/pgdg-release.rpm; \
+    microdnf -y install \
+        postgis34_${PG_MAJOR} \
+        postgis34_${PG_MAJOR}-client; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
+
+USER 26

--- a/Dockerfile.postgis
+++ b/Dockerfile.postgis
@@ -5,30 +5,19 @@ ARG PG_MAJOR=16
 FROM ${REGISTRY}:${BASE_TAG}
 
 ARG PG_MAJOR
-ARG TARGETARCH
 
 LABEL maintainer="Fly.io" \
       description="PostgreSQL with PostGIS and Patroni for the Percona Operator 2.6"
 
 USER 0
 
-# ── PostGIS via PGDG ──────────────────────────────────────────────────────────
-# Percona's repos don't include PostGIS; PGDG is the canonical source.
-# PGDG postgres packages (postgresql${PG_MAJOR}-*) have different names than
-# Percona's (percona-postgresql${PG_MAJOR}-*), so there are no conflicts.
+# ── PostGIS via Percona repo ──────────────────────────────────────────────────
+# percona-postgis33 pulls in gdal311-libs, which requires libqhull_r.
+# libqhull_r lives in Oracle Linux CRB — enable it just for this install.
 RUN set -ex; \
-    case "${TARGETARCH}" in \
-      amd64) PGDG_ARCH="x86_64" ;; \
-      arm64) PGDG_ARCH="aarch64" ;; \
-      *)     PGDG_ARCH=$(uname -m) ;; \
-    esac; \
-    curl -Lfs -o /tmp/pgdg-release.rpm \
-        "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-${PGDG_ARCH}/pgdg-redhat-repo-latest.noarch.rpm"; \
-    rpm -i /tmp/pgdg-release.rpm; \
-    rm -f /tmp/pgdg-release.rpm; \
-    microdnf -y install \
-        postgis34_${PG_MAJOR} \
-        postgis34_${PG_MAJOR}-client; \
+    microdnf --enablerepo=ol9_codeready_builder -y install \
+        percona-postgis33_${PG_MAJOR} \
+        percona-postgis33_${PG_MAJOR}-client; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,6 +1,6 @@
-FROM pgsty/pg_exporter:1.0.2 as base
+FROM pgsty/pg_exporter:1.2.2 as base
 
-FROM pgsty/pg_exporter:1.0.2
+FROM pgsty/pg_exporter:1.2.2
 
 COPY --from=base /etc/pg_exporter.yml /etc/pg_exporter/pg_exporter.yml
 

--- a/scripts/crunchy/bin/postgres/pgbackrest_info.sh
+++ b/scripts/crunchy/bin/postgres/pgbackrest_info.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2019 - 2022 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /tmp/pgbackrest_env.sh > /tmp/pgbackrest_env.stdout 2> /tmp/pgbackrest_env.stderr
+
+cmd_args=()
+# if TLS verification is disabled, pass in the appropriate flag
+# otherwise, leave the default behavior and verify TLS
+if [[ "${PGHA_PGBACKREST_S3_VERIFY_TLS}" == "false" ]]
+then
+    cmd_args+=("--no-repo1-s3-verify-tls")
+fi
+
+echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --output=json ${cmd_args[*]} info | tr -d '\n')

--- a/scripts/patroni-wrapper.sh
+++ b/scripts/patroni-wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# OOM protection wrapper for patroni.
+#
+# The Percona Operator sets command=["patroni", "/etc/patroni"] on the pod spec,
+# bypassing the Docker ENTRYPOINT. By placing this script at /usr/bin/patroni
+# and renaming the real binary to /usr/bin/patroni-real, we intercept the call.
+#
+# NOTE: Writing to oom_score_adj requires CAP_SYS_RESOURCE or running as root.
+# If the pod security context runs as UID 26, the echo below will fail silently.
+# To make OOM protection effective, grant the container CAP_SYS_RESOURCE or
+# run an init container that sets /proc/1/oom_score_adj for the pod.
+
+if [ -f "/proc/self/oom_score_adj" ]; then
+    echo -900 > /proc/self/oom_score_adj 2>/dev/null || true
+fi
+
+nohup /usr/local/bin/postgres-oom-adjuster.sh >> /tmp/postgres-oom-adjuster.log 2>&1 &
+
+export PG_OOM_ADJUST_FILE=/proc/self/oom_score_adj
+export PG_OOM_ADJUST_VALUE=0
+
+exec /usr/bin/patroni-real "$@"

--- a/scripts/relocate-extensions.sh
+++ b/scripts/relocate-extensions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+PG_EXTENSIONS_DIR=/usr/pgsql-${PG_VERSION}/share/extension
+PG_LIB_DIR=/usr/pgsql-${PG_VERSION}/lib
+
+PGDATA_EXTENSIONS_DIR=/pgdata/extension/${PG_VERSION}/usr/pgsql-${PG_VERSION}/share/extension
+PGDATA_LIB_DIR=/pgdata/extension/${PG_VERSION}/usr/pgsql-${PG_VERSION}/lib
+
+mkdir -p ${PGDATA_EXTENSIONS_DIR}
+mkdir -p ${PGDATA_LIB_DIR}
+
+cp -r ${PG_EXTENSIONS_DIR}/* ${PGDATA_EXTENSIONS_DIR}/
+cp -r ${PG_LIB_DIR}/* ${PGDATA_LIB_DIR}/


### PR DESCRIPTION
Here we introduce a second type of postgres images: based on percona's
but built from scratch. They are prefixed with "fly-" and contain the
scripts needed by the operator v2.6. Postgres and Patroni were updated
to their latest minor versions.

Also includes a small refactor for workflows: exporter was separated and
workflows depend on files explicitly, avoiding building all images on
every change.

Signed-off-by: Juliana Oliveira <juliana@fly.io>
